### PR TITLE
chore: ajout licence EUPL 1.2 FR

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,97 @@
+LICENCE PUBLIQUE DE L'UNION EUROPÉENNE v. 1.2 
+EUPL © Union européenne 2007, 2016
+
+La présente licence publique de l'Union européenne («EUPL») s'applique à toute œuvre (telle que définie ci-dessous) fournie aux conditions prévues par la présente licence. Toute utilisation de l'œuvre autre que ce qu'autorise la présente licence est interdite (dans la mesure où pareille utilisation est couverte par un droit du titulaire des droits d'auteur sur l'œuvre). L'œuvre est fournie aux conditions prévues par la présente licence quand le donneur de licence (tel que défini ci-dessous) a placé la mention suivante immédiatement après la déclaration relative au droit d'auteur sur l'œuvre: 
+                                   Sous licence EUPL
+ou a exprimé de toute autre manière sa volonté de fournir l'œuvre sous licence EUPL. 
+
+1.Définitions 
+Dans la présente licence, on entend par: 
+—  «licence», la présente licence, 
+—  «œuvre originale», l'œuvre ou le logiciel distribué ou communiqué par le donneur de licence en vertu de la présente licence, sous forme de code source ou de code objet, selon le cas, 
+—  «œuvres dérivées», les œuvres ou logiciels qui pourraient être créés par le licencié sur la base de l'œuvre originale ou des modifications qui y auraient été appliquées. La présente licence ne définit pas le degré de modification ou de dépendance requis par rapport à l'œuvre originale pour qu'une œuvre soit qualifiée d'œuvre dérivée; cette question est réglée par la loi applicable en matière de droit d'auteur dans le pays visé à l'article 15, 
+—  «œuvre», l'œuvre originale ou ses œuvres dérivées, 
+—  «code source», la forme de l'œuvre, lisible par l'homme, la plus appropriée pour que des personnes puissent l'examiner et la modifier, 
+—  «code objet», l'œuvre codée, généralement après compilation, destinée à être exécutée en tant que programme par un ordinateur, —  «donneur de licence», la personne physique ou morale qui distribue ou communique l'œuvre sous licence, 
+—  «contributeur», toute personne physique ou morale qui modifie l'œuvre sous licence, ou contribue de toute autre manière à en faire une œuvre dérivée, 
+—  «licencié» ou «vous», toute personne physique ou morale qui utilise l'œuvre conformément à la licence, 
+—  «distribution» ou «communication», tout acte de vente, don, prêt, location, distribution, communication, transmission ou mise à disposition, en ligne ou hors ligne, de copies de l'œuvre, et tout acte donnant accès à ses fonctions essentielles à toute autre personne physique ou morale. 
+
+2.Portée des droits accordés par la licence 
+Par la présente, le donneur de licence vous concède, pour la durée de la protection de son droit d'auteur sur l'œuvre originale, une licence mondiale, libre de redevances, non exclusive et pouvant faire l'objet de sous-licences, en vertu de laquelle vous pouvez: 
+—  utiliser l'œuvre en toute circonstance et pour tout usage, 
+—  reproduire l'œuvre, 
+—  modifier l'œuvre et créer des œuvres dérivées sur la base de l'œuvre, 
+—  communiquer l'œuvre au public, ce qui inclut le droit de mettre à disposition du public ou de lui présenter l'œuvre ou des copies de l'œuvre et d'en effectuer des représentations publiques, le cas échéant, 
+—  distribuer l'œuvre ou des copies de celle-ci, 
+—  prêter et louer l'œuvre ou des copies de celles-ci, 
+—  accorder en sous-licence des droits sur l'œuvre ou sur des copies de celle-ci. 
+Ces droits peuvent être exercés sur tout support et format, connu ou encore à inventer, dans la mesure où le droit applicable le permet. Dans les pays où des droits moraux s'appliquent, le donneur de licence renonce à son droit d'exercer son droit moral dans la mesure permise par la loi afin que la licence sur les droits patrimoniaux susmentionnés produise ses effets. Le donneur de licence vous concède un droit d'usage libre de redevances et non exclusif sur tout brevet qu'il détient, dans la mesure nécessaire à l'exercice des droits qui vous sont concédés sur l'œuvre sous licence. 
+
+3.Communication du code source 
+Le donneur de licence fournit l'œuvre sous forme de code source ou de code objet. Si l'œuvre est fournie sous forme de code objet, le donneur de licence accompagne chacune des copies de l'œuvre qu'il distribue d'une copie lisible par machine du code source de l'œuvre ou indique, dans un avis qui suit la déclaration relative au droit d'auteur jointe à l'œuvre, l'endroit où le code source est aisément et gratuitement accessible aussi longtemps que le donneur de licence continue à distribuer ou communiquer l'œuvre. 
+
+4.Limitations du droit d'auteur 
+Rien dans la présente licence n'a pour but de priver le licencié des avantages résultant de toute exception ou limitation aux droits exclusifs des titulaires de droits sur l'œuvre, de l'épuisement de ces droits ou de toute autre limitation qui s'y applique. 
+
+5.Obligations du licencié 
+La concession des droits susmentionnés est soumise à des restrictions et à des obligations pour le licencié. Ces obligations sont les suivantes: 
+
+Droit d'attribution: le licencié laisse intactes toutes les déclarations concernant le droit d'auteur, le brevet ou les marques et toutes les déclarations concernant la licence et l'exclusion de garantie. Le licencié assortit chaque copie de l'œuvre qu'il distribue ou communique d'une copie de ces déclarations et d'une copie de la licence. Le licencié veille à ce que toute œuvre dérivée soit assortie d'un avis bien visible indiquant que l'œuvre a été modifiée et mentionnant la date de la modification. 
+
+Clause copyleft: si le licencié distribue ou communique des copies d'œuvres originales ou d'œuvres dérivées, cette distribution ou cette communication est effectuée dans les conditions prévues par la présente licence ou une version ultérieure de cette licence, sauf si l'œuvre originale est expressément distribuée en vertu de la présente version de la licence uniquement, par exemple au moyen de la mention «EUPL v. 1.2 seulement». Le licencié (qui devient donneur de licence) ne peut pas, en ce qui concerne l'œuvre ou les œuvres dérivées, offrir ou imposer des conditions supplémentaires qui restreignent ou modifient les conditions de la licence. 
+
+Clause de compatibilité: si le licencié distribue ou communique des œuvres dérivées ou des copies de telles œuvres basées à la fois sur l'œuvre et sur une autre œuvre concédée sous une licence compatible, la distribution ou la communication peut être faite aux conditions de cette licence compatible. Aux fins de la présente clause, une «licence compatible» est l'une des licences énumérées dans l'appendice de la présente licence. Dans le cas où les obligations du licencié au titre de la licence compatible entrent en conflit avec les obligations du licencié au titre de la présente licence, les premières prévalent. 
+
+Fourniture du code source: lorsqu'il distribue ou communique des copies de l'œuvre, le licencié fournit une copie lisible par machine du code source ou indique l'endroit où ce code source restera aisément et gratuitement accessible aussi longtemps que le donneur de licence continuera à distribuer ou communiquer l'œuvre. 
+
+Protection des droits: la présente licence ne donne pas le droit d'utiliser les noms commerciaux, les marques commerciales, les marques de service ou les noms du donneur de licence, sauf dans la mesure nécessaire, conformément à une utilisation raisonnable et aux pratiques habituelles, pour décrire l'origine de l'œuvre et reproduire la déclaration concernant le droit d'auteur.
+
+6.Chaîne d'auteurs 
+Le donneur de licence initial garantit que les droits d'auteur sur l'œuvre originale concédés par la présente licence lui appartiennent ou lui ont été donnés sous licence, et qu'il a le pouvoir et la capacité de concéder la licence. Tout contributeur garantit que les droits d'auteur sur les modifications qu'il apporte à l'œuvre lui appartiennent ou lui ont été donnés sous licence, et qu'il a le pouvoir et la capacité de concéder la licence. Chaque fois que vous acceptez la licence, le donneur de licence initial et les contributeurs successifs vous concèdent une licence sur leurs contributions à l'œuvre selon les conditions de la présente licence. 
+
+7.Exclusion de garantie 
+L'œuvre est un travail en cours, amélioré de manière continue par de nombreux contributeurs. Elle constitue un travail inachevé et peut dès lors contenir des défauts ou bogues inhérents à ce type de développement. Pour cette raison, l'œuvre est fournie sous licence telle quelle, sans aucune garantie d'aucune sorte la concernant, y compris, sans que cette liste soit exhaustive, eu égard à sa qualité marchande, son aptitude à un usage particulier, l'absence de défauts ou d'erreurs, l'exactitude ou la non-violation de droits de propriété intellectuelle autres que le droit d'auteur comme prévu à l'article 6 de la présente licence. Cette exclusion de garantie est une partie essentielle de la licence et une condition de la concession de droits sur l'œuvre. 
+
+8.Exclusion de responsabilité 
+Sauf dans les cas de faute intentionnelle ou de dommages directement causés à des personnes physiques, le donneur de licence n'est en aucun cas responsable des dommages, quelle qu'en soit la nature, directs ou indirects, matériels ou moraux, résultant de la licence ou de l'utilisation de l'œuvre, y compris, sans que cette liste soit exhaustive, des dommages causés par les atteintes à la réputation, les interruptions de travail, les défaillances ou le mauvais fonctionnement de matériel informatique, les pertes de données ou tout autre dommage économique, même si le donneur de licence a été informé de la possibilité de tels dommages. Cependant, le donneur de licence est responsable en vertu des dispositions législatives et réglementaires relatives à la responsabilité du fait des produits, dans la mesure où celles-ci sont applicables à l'œuvre. 
+
+9.Accords additionnels 
+Lorsque vous distribuez l'œuvre, vous pouvez choisir de conclure un accord additionnel définissant des obligations ou des services compatibles avec la présente licence. Cependant, si vous acceptez des obligations, vous ne pouvez agir qu'en votre nom et sous votre seule responsabilité, et non au nom du donneur de licence initial ou de tout autre contributeur, et seulement si vous acceptez d'indemniser, de défendre et de mettre hors de cause tous les contributeurs s'ils encourent une responsabilité quelconque ou si des réclamations sont formulées à leur encontre du fait que vous avez accepté des garanties ou des responsabilités additionnelles. 
+
+10.Acceptation de la licence
+Vous pouvez exprimer votre accord sur le contenu de la présente licence en cliquant sur l'icône «J'accepte» placée au bas d'une fenêtre faisant apparaître le texte de la présente licence, ou par toute autre manifestation de consentement similaire, conformément à la loi applicable. Le fait de cliquer sur cette icône indique votre acceptation claire et irrévocable de la présente licence et de toutes ses conditions. De même, vous acceptez irrévocablement la présente licence et toutes ses conditions dès lors que vous exercez un des droits qui vous sont concédés par l'article 2 de la présente licence, tels que l'utilisation de l'œuvre, la création d'une œuvre dérivée ou la distribution ou la communication de l'œuvre ou de copies de l'œuvre. 
+
+11.Information du public
+En cas de distribution ou de communication électronique de l'œuvre (par exemple en permettant son téléchargement à distance), le canal de distribution ou le support (par exemple un site web) doit au minimum fournir au public les informations requises par le droit applicable en ce qui concerne le donneur de licence et la licence ainsi que la manière dont le licencié peut accéder à celle-ci, la conclure, la stocker et la reproduire.
+
+12.Fin de la licence
+La licence et les droits qu'elle concède prennent automatiquement fin dès que le licencié viole l'une de ses conditions. Un tel événement ne met pas fin aux licences des personnes ayant reçu l'œuvre sous licence de la part du licencié, pour autant que ces personnes respectent pleinement la licence. 
+
+13.Divers
+Sous réserve de l'article 9, la licence représente l'entièreté de l'accord entre les parties quant à l'œuvre. Le fait qu'une clause quelconque de la licence soit invalide ou inapplicable en vertu du droit applicable n'affecte pas la validité ou l'applicabilité de la licence dans son ensemble. Une telle clause sera interprétée ou modifiée dans la mesure nécessaire pour la rendre valide ou applicable. La Commission européenne peut publier d'autres versions linguistiques ou de nouvelles versions de la présente licence ou des versions actualisées de son appendice, dans la mesure de ce qui est nécessaire et raisonnable, sans réduire la portée des droits accordés par la licence. Les nouvelles versions de la licence seront publiées avec un numéro de version unique. Toutes les versions linguistiques de la présente licence, approuvées par la Commission européenne, ont la même valeur. Les parties peuvent se prévaloir de la version linguistique de leur choix. 
+
+14.Juridiction compétente
+Sans préjudice d'accords spécifiques entre les parties, 
+— tout litige résultant de l'interprétation de la présente licence survenant entre des institutions, organes, bureaux ou agences de l'Union européenne en tant que donneurs de licence et un licencié relève de la juridiction de la Cour de justice de l'Union européenne, conformément à l'article 272 du traité sur le fonctionnement de l'Union européenne, 
+— tout litige survenant entre d'autres parties et résultant de l'interprétation de la présente licence relève de la compétence exclusive de la juridiction compétente du lieu où le donneur de licence réside ou exerce son activité principale. 
+
+15.Droit applicable
+Sans préjudice d'accords spécifiques entre les parties, 
+— la présente licence est régie par le droit de l'État membre de l'Union européenne où le donneur de licence réside ou a son siège social ou statutaire, 
+— la présente licence est régie par le droit belge si le donneur de licence ne réside pas et n'a pas son siège social ou statutaire dans un État membre de l'Union européenne.  
+    
+Appendice 
+Aux fins de l'article 5 de l'EUPL, les licences compatibles sont les suivantes: 
+—  GNU General Public License (GPL) v. 2, v. 3 
+—  GNU Affero General Public License (AGPL) v. 3 
+—  Open Software License (OSL) v. 2.1, v. 3.0 
+—  Eclipse Public License (EPL) v. 1.0 
+—  CeCILL v. 2.0, v. 2.1 
+—  Mozilla Public licence (MPL) v. 2 
+—  GNU Lesser General Public licence (LGPL) v. 2.1, v. 3 
+—  Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) pour les œuvres autres que logicielles 
+—  Licence publique de l'Union européenne (EUPL) v. 1.1, v. 1.2 
+—  Licence libre du Québec — Réciprocité (LiLiQ-R) ou Réciprocité forte (LiLiQ-R+) 
+La Commission européenne pourra actualiser le présent appendice afin d'y inclure des versions ultérieures des licences ci-dessus sans produire de nouvelle version de l'EUPL, dès lors que ces versions prévoient la concession des droits visés à l'article 2 de la présente licence et empêchent l'appropriation exclusive du code source couvert. 
+Tout autre changement ou ajout au présent appendice requiert la production d'une nouvelle version de l'EUPL.


### PR DESCRIPTION
## Summary
- Ajout du fichier LICENSE avec le texte officiel français de l'EUPL v1.2
- Source : site officiel de la Commission européenne (interoperable-europe.ec.europa.eu)
- UTF-8 sans BOM, 15 articles + appendice complet

## Test plan
- [x] Vérifier les 15 articles présents
- [x] Vérifier l'appendice avec licences compatibles
- [x] Vérifier encodage UTF-8 sans BOM
- [x] Fichier identique entre private et public

🤖 Generated with [Claude Code](https://claude.com/claude-code)