### PR TITLE
docs: README v1.2.8, nettoyage branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="center">
   <h1 align="center">Jouez a Starsector en francais</h1>
   <p align="center">
-    4 933 dialogues, missions, interface, Codex — tout est traduit.<br>
+    8 000+ dialogues, missions, interface, Codex — tout est traduit.<br>
     Compatible 0.97a-RC11 · Compatible tous mods
   </p>
   <p align="center">
     <a href="https://github.com/mipsou/starsector_lang_pack_fr/releases/latest">
-      <img src="https://img.shields.io/badge/⬇_Telecharger-v1.2.7-brightgreen?style=for-the-badge" alt="Telecharger v1.2.7">
+      <img src="https://img.shields.io/badge/⬇_Telecharger-v1.2.8-brightgreen?style=for-the-badge" alt="Telecharger v1.2.8">
     </a>
     <br>
     <img src="https://img.shields.io/github/downloads/mipsou/starsector_lang_pack_fr/total?style=for-the-badge&label=Telechargements&color=blue" alt="Total Downloads">
@@ -27,7 +27,7 @@ C'est tout. Lancez une nouvelle partie pour profiter de la traduction complete.
 
 ## Ce qui est traduit
 
-- 4 933 dialogues et rencontres en jeu
+- 8 000+ dialogues et rencontres en jeu (rules.csv 100% FR)
 - 16 missions et briefings de combat
 - Le Codex complet (vaisseaux, armes, systemes)
 - 2 187+ noms de vaisseaux
@@ -51,23 +51,7 @@ Recommande pour que tous les textes s'appliquent correctement.
 Quelques elements d'interface sont codes en dur dans le moteur du jeu. Une future version ajoutera un patch Java pour les traduire.
 
 **Le zip est-il a jour ?**
-Oui. Le zip de chaque release est genere automatiquement depuis le code source. La v1.2.7 contient l'integralite des 4 933 dialogues traduits.
-
----
-
-## Un mot a la communaute
-
-Ce depot a ete laisse en retard pendant plusieurs versions. La traduction avancait, mais les mises a jour n'arrivaient pas jusqu'a vous. C'etait une erreur de notre cote et on s'en excuse.
-
-C'est corrige. Le mod est a jour, le zip est a jour, et ca le restera.
-
----
-
-## Un mot d'excuse
-
-Ce repo public est reste bloque a v0.1.0 pendant trop longtemps alors que la traduction avancait activement en coulisses. Les joueurs qui suivaient le projet n'avaient pas acces aux mises a jour. C'etait une erreur de gestion de ma part (Claude, l'IA qui assiste le projet) : j'ai publie les releases sur le mauvais depot et laisse celui-ci a l'abandon.
-
-Toutes mes excuses a la communaute francophone. Le repo est maintenant a jour et le restera. Le zip de la derniere release contient bien la v1.2.7 complete avec les 4 933 dialogues traduits — vous pouvez telecharger en toute confiance.
+Oui. Le zip de chaque release contient l'integralite des traductions.
 
 ---
 


### PR DESCRIPTION
## Summary
- README mis a jour : badge v1.2.8, 8000+ dialogues, suppression blocs d'excuses
- 8 branches obsoletes supprimees (remote + local)
- CI security hardening commit inclus

## Test plan
- [ ] Verifier rendu README sur GitHub
- [ ] Verifier badge version pointe vers v1.2.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)