### PR TITLE
fix: mod_info.json v1.9.1 — retirer _dev et [DEV]

### DIFF
--- a/mod_info.json
+++ b/mod_info.json
@@ -1,6 +1,6 @@
 {
-  "id": "starsector_lang_pack_fr_dev",
-  "name": "Starsector Language Pack - French [DEV]",
+  "id": "starsector_lang_pack_fr",
+  "name": "Starsector Language Pack - French",
   "author": "mipsou",
   "totalConversion": "false",
   "utility": "true",


### PR DESCRIPTION
Fix critique : le mod_info.json contenait l'ID dev et le tag [DEV].