### PR TITLE
docs: badge inclut les pre-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > 40 000+ dialogues, missions, Codex, compétences traduits.
 > Compatible 0.98a-RC8
 
-[![Télécharger](https://img.shields.io/github/v/release/mipsou/starsector_lang_pack_fr?style=for-the-badge&label=⬇_Télécharger&color=brightgreen)](https://github.com/mipsou/starsector_lang_pack_fr/releases/latest)
+[![Télécharger](https://img.shields.io/github/v/release/mipsou/starsector_lang_pack_fr?include_prereleases&style=for-the-badge&label=⬇_Télécharger&color=brightgreen)](https://github.com/mipsou/starsector_lang_pack_fr/releases/latest)
 ![Téléchargements](https://img.shields.io/github/downloads/mipsou/starsector_lang_pack_fr/total?style=for-the-badge&label=Téléchargements&color=blue)
 ![Starsector](https://img.shields.io/badge/Starsector-0.98a--RC8-orange?style=for-the-badge)
 


### PR DESCRIPTION
Ajoute include_prereleases au badge pour afficher v2.0.0-rc1