### PR TITLE
docs(examples): plugin Java squelette pour traducteurs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,40 @@
+# Examples — minimal language mod plugin
+
+This folder contains a **minimal Java plugin skeleton** for anyone who wants to translate Starsector to another language.
+
+## What it does
+
+Starsector hardcodes some UI strings directly in Java (not in CSV/JSON). To translate them, you need a mod plugin that intercepts and replaces them at runtime.
+
+The example in `src/data/scripts/LangModPlugin.java` shows **one concrete case**: translating the hardcoded dialog prompt `"You decide to..."` to French.
+
+## How to adapt for your language
+
+1. **Change the translation** in `LangModPlugin.java`:
+   ```java
+   private static final String REPLACEMENT = "Your translation here";
+   ```
+
+2. **Rename the class** (e.g. `SpanishLangModPlugin`) to avoid conflicts with other language mods.
+
+3. **Compile to a JAR** targeting Java 7 (Starsector's JRE):
+   ```bash
+   javac -cp "path/to/starfarer_api.jar" -d build src/data/scripts/*.java
+   jar cf jars/yourlang.jar -C build .
+   ```
+
+4. **Reference the JAR** in your `mod_info.json`:
+   ```json
+   "jars": ["jars/yourlang.jar"],
+   "modPlugin": "data.scripts.SpanishLangModPlugin"
+   ```
+
+## Constraints
+
+- **No reflection** — Starsector's sandbox blocks `java.lang.reflect`.
+- **Null-guard everything** — API access can return null during loading/combat screens.
+- **Never crash** — always wrap in try/catch with English fallback.
+
+## License
+
+EUPL 1.2 — you can fork and adapt for any language. Keep the EUPL license on your fork (copyleft).

--- a/examples/src/data/scripts/LangModPlugin.java
+++ b/examples/src/data/scripts/LangModPlugin.java
@@ -1,0 +1,56 @@
+package data.scripts;
+
+import com.fs.starfarer.api.BaseModPlugin;
+import com.fs.starfarer.api.EveryFrameScript;
+import com.fs.starfarer.api.Global;
+import com.fs.starfarer.api.campaign.InteractionDialogAPI;
+
+/**
+ * Minimal language mod plugin — example translating ONE hardcoded Java string.
+ *
+ * How it works:
+ *   Starsector hardcodes "You decide to..." in dialog prompts (not externalized in CSV/JSON).
+ *   An EveryFrameScript watches the active dialog and swaps the prompt text with our translation.
+ *
+ * To adapt for another language:
+ *   1. Change the translation string below.
+ *   2. Rename this class (e.g. SpanishLangModPlugin) and keep only ONE plugin per mod.
+ *   3. Compile to a JAR, reference it in mod_info.json via "jars": ["jars/yourlang.jar"].
+ *
+ * Constraints:
+ *   - No reflection (Starsector sandbox blocks java.lang.reflect).
+ *   - Null-guard every API access — no crashes during loading/combat screens.
+ */
+public class LangModPlugin extends BaseModPlugin {
+
+    // Your translation here — replace with your target language
+    private static final String TARGET = "You decide to...";
+    private static final String REPLACEMENT = "Vous décidez de...";
+
+    @Override
+    public void onGameLoad(boolean newGame) {
+        Global.getSector().addTransientScript(new PromptTranslator());
+    }
+
+    /** Runs every frame, replaces the hardcoded prompt when it appears. */
+    static class PromptTranslator implements EveryFrameScript {
+        public boolean isDone() { return false; }
+        public boolean runWhilePaused() { return true; }
+
+        public void advance(float amount) {
+            try {
+                if (Global.getSector() == null) return;
+                if (Global.getSector().getCampaignUI() == null) return;
+
+                InteractionDialogAPI dialog = Global.getSector().getCampaignUI().getCurrentInteractionDialog();
+                if (dialog == null) return;
+
+                if (TARGET.equals(dialog.getPromptText())) {
+                    dialog.setPromptText(REPLACEMENT);
+                }
+            } catch (Exception e) {
+                // Fallback EN if anything goes wrong — never crash the game
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ajoute un exemple minimal (50 lignes) pour aider tout futur traducteur (ES, DE, IT, etc.) à traduire les textes hardcodés Java.

Contient :
- examples/src/data/scripts/LangModPlugin.java (plugin + EveryFrameScript exemple)
- examples/README.md (instructions compilation + contraintes)