### PR TITLE
release: v2.0.3 — patch d'urgence crash mods (issue #127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2.0.3] - 2026-05-15
+
+### 🚨 Corrigé — Crash critique avec mods (issue #127)
+
+Suite à un rapport de [@Demotion89](https://github.com/Demotion89) qui rencontrait un crash avec une stack de 25 mods (Nexerelin, Industrial Evolution, Terraforming, etc.), analyse profonde de `rules.csv` :
+
+- **Variable `$hate` corrompue en `$hâte`** (9 occurrences) — variable Java de réputation NPC traduite par erreur par un sed global. Cause probable du crash avec Nexerelin qui manipule cette variable.
+- **Variable `$gaDA_rew` tronquée** (3 occurrences) → restaurée en `$gaDA_reward` (missions Galatia Academy)
+- **`$fleetOrShip` inventée** (1 occurrence) → corrigée en `$shipOrFleet`
+- **`$eOr` et `$eOrE` artefacts** (2 occurrences) → supprimés (étaient des tentatives de gérer l'accord masculin/féminin en français, non supportées par le moteur Starsector)
+
+### Impact joueurs
+
+- Joueurs avec **stack mods + Nexerelin** : fix du crash signalé
+- Joueurs **vanilla seul** : pas d'impact visible (les dialogues SDTU/Macario fonctionnent à nouveau correctement)
+- Variables d'accord genré (`hisOrHer`, etc.) : 5 cas isolés où la traduction a perdu la dynamique de genre — à traiter en release ultérieure (pas critique)
+
 ## [2.0.2] - 2026-04-26
 
 ### Corrigé

--- a/mod_info.json
+++ b/mod_info.json
@@ -4,7 +4,7 @@
   "author": "mipsou",
   "totalConversion": "false",
   "utility": "true",
-  "version": {"major":2, "minor":0, "patch":2},
+  "version": {"major":2, "minor":0, "patch":3},
   "description": "Pack de langue francais pour Starsector. GitHub: github.com/mipsou/starsector_lang_pack_fr | Forum: fractalsoftworks.com/forum/index.php?topic=35135.0",
   "gameVersion": "0.98a-RC8",
   "modPlugin": "data.scripts.FrenchLangModPlugin",


### PR DESCRIPTION
## Summary

Patch hotfix v2.0.3 suite à l'issue #127 (crash signalé par @Demotion89 avec stack Nexerelin + 24 mods).

## Bugs critiques corrigés (rules.csv)

### 🔴 \`\$hate\` corrompu en \`\$hâte\` (9 occurrences)
Variable Java de réputation NPC traduite par erreur par un sed global lors de la traduction. Cause probable du crash avec Nexerelin qui manipule cette variable de réputation.

### 🟠 Autres variables corrompues
- \`\$gaDA_rew\` (3×) → \`\$gaDA_reward\` (troncation, missions Galatia Academy)
- \`\$fleetOrShip\` (1×) → \`\$shipOrFleet\` (ordre inversé)
- \`un\$eOr\` (1×) → \`un\` (artefact \"un/une\" non supporté)
- \`horrifié\$eOrE\` (1×) → \`horrifié\` (artefact accord, non supporté)

## QA validée

- [x] validate_csv.py OK (parité guillemets, field count)
- [x] Test en jeu : chargement sans erreur
- [x] 0 variable inventée restante
- [x] 11108 records, 7 colonnes par row
- [x] PR privée #124 mergée

## Impact joueurs

| Profil | Impact |
|---|---|
| Stack mods + Nexerelin | ✅ Crash fixé |
| Vanilla seul | ✅ Dialogues SDTU/Macario à nouveau corrects |
| Toutes configs | ✅ Aucune régression attendue |

Closes #127